### PR TITLE
CreateHugPage input and button fixed

### DIFF
--- a/frontend/src/pages/off-nav/CreateHugPage.js
+++ b/frontend/src/pages/off-nav/CreateHugPage.js
@@ -209,17 +209,15 @@ export default function CreateHugPage({ navigation, route }) {
       },  
       backgroundImg: {
         height: windowHeight,
-        resizeMode: 'contain',
-        zIndex: 0,
-        position: 'absolute'
-        // shadowColor: '#000',
-        // shadowOffset: {
-        //     width: 0,
-        //     height: 2,
-        // },
-        // shadowOpacity: 0.3,
-        // shadowRadius: 2,
-        // elevation: 4,
+        resizeMode: 'cover',
+        shadowColor: '#000',
+        shadowOffset: {
+            width: 0,
+            height: 2,
+        },
+        shadowOpacity: 0.3,
+        shadowRadius: 2,
+        elevation: 4,
       },
       header: {
         width: windowWidth,
@@ -271,7 +269,7 @@ export default function CreateHugPage({ navigation, route }) {
           >
             {/* Header */}
             {/* View centers the Header */}
-            <View style={{alignItems: 'center'}}>
+            <View style={{alignItems: 'center', backgroundColor: 'pink'}}>
               <Header 
                 routeName={routeName} 
                 navigation={navigation} 

--- a/frontend/src/pages/onboarding/LoginPage.js
+++ b/frontend/src/pages/onboarding/LoginPage.js
@@ -27,10 +27,8 @@ import Header from 'components/Header'
 
 export default function LoginPage({ navigation, route }) {
   // States
-  const [emailField, setEmailField] = useState('rikhilna@gmail.com');
-  // const [emailField, setEmailField] = useState('Alex@mail.com');
-  // const [passwordField, setPasswordField] = useState('password');
-  const [passwordField, setPasswordField] = useState('gggggg');
+  const [emailField, setEmailField] = useState(''); // rikhilna@gmail.com
+  const [passwordField, setPasswordField] = useState(''); // gggggg
   const [loggingIn, setLoggingIn] = useState(false);
   const [startUp, setStartUp] = useState(true);
   const [isKeyboardVisible, setKeyboardVisible] = useState(false);


### PR DESCRIPTION
Style for backgroundImg covered the whole screen and prevented users from inputting text and attaching images. This is now fixed.